### PR TITLE
 spring-boot-starter-tomcat to 2.0.7.RELEASE , upgrade javax.servlet-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<version>2.0.7.RELEASE</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -86,7 +87,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -112,10 +113,10 @@
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
 		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
+			<!--            <plugin>-->
+			<!--                <groupId>org.springframework.boot</groupId>-->
+			<!--                <artifactId>spring-boot-maven-plugin</artifactId>-->
+			<!--            </plugin>-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
…api to 3.1.0 to fix NoSuchMethodError:javax.servlet.ServletContext.getVirtualServerName()